### PR TITLE
Do not sort constructors

### DIFF
--- a/ssf/src/types/algebraic.rs
+++ b/ssf/src/types/algebraic.rs
@@ -1,13 +1,12 @@
 use super::constructor::Constructor;
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Algebraic {
     constructors: Vec<Constructor>,
 }
 
 impl Algebraic {
-    pub fn new(mut constructors: Vec<Constructor>) -> Self {
-        constructors.sort();
+    pub fn new(constructors: Vec<Constructor>) -> Self {
         Self { constructors }
     }
 
@@ -54,15 +53,19 @@ mod tests {
         );
         assert_eq!(
             &Algebraic::new(vec![
+                Constructor::new(vec![]),
+                Constructor::new(vec![Primitive::Float64.into()])
+            ])
+            .to_id(),
+            "{{},{Float64}}"
+        );
+        assert_eq!(
+            &Algebraic::new(vec![
                 Constructor::new(vec![Primitive::Float64.into()]),
                 Constructor::new(vec![])
             ])
             .to_id(),
-            &Algebraic::new(vec![
-                Constructor::new(vec![]),
-                Constructor::new(vec![Primitive::Float64.into()])
-            ])
-            .to_id()
+            "{{Float64},{}}"
         );
     }
 }

--- a/ssf/src/types/constructor.rs
+++ b/ssf/src/types/constructor.rs
@@ -1,6 +1,6 @@
 use super::type_::Type;
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Constructor {
     elements: Vec<Type>,
 }

--- a/ssf/src/types/function.rs
+++ b/ssf/src/types/function.rs
@@ -2,7 +2,7 @@ use super::type_::Type;
 use super::value::Value;
 use std::rc::Rc;
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Function {
     arguments: Vec<Type>,
     result: Rc<Value>,

--- a/ssf/src/types/primitive.rs
+++ b/ssf/src/types/primitive.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Primitive {
     Float64,
     Integer64,

--- a/ssf/src/types/type_.rs
+++ b/ssf/src/types/type_.rs
@@ -1,7 +1,7 @@
 use super::function::Function;
 use super::value::Value;
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Type {
     Function(Function),
     Value(Value),

--- a/ssf/src/types/value.rs
+++ b/ssf/src/types/value.rs
@@ -1,7 +1,7 @@
 use super::algebraic::Algebraic;
 use super::primitive::Primitive;
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Value {
     Algebraic(Algebraic),
     Index(usize),


### PR DESCRIPTION
This PR lets algebraic types hold constructors in arrays instead of ordered sets.

While the language is structurally-typed, using ordered sets of constructors in each algebraic is not really behaviour comprehensive to users.